### PR TITLE
Add the ability to pass in a value argument to genNew

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -735,15 +735,17 @@ export class List extends Component {
   // If there is an index go to the detail view of that item
   // otherwise create a new record
   // if a value is passed in, that will override an existing value
-  genNew(index, value=null){
+  genNew(index, passedInValue=null){
     const { options, ctx } = this.props;
     const auto = this.getAuto();
     const i18n = this.getI18n();
     const config = this.getConfig();
     const stylesheet = this.getStylesheet();
     const templates = this.getTemplates();
-    const initialValue = value ? value : this.state.value[index]
-    const itemValue = Number.isInteger(index) ? initialValue : null;
+    let itemValue = passedInValue
+    if (!passedInValue) {
+        itemValue = Number.isInteger(index) ? this.state.value[index] : null
+    }
     const i = Number.isInteger(index) ? index : this.state.value.length
     const type = this.typeInfo.innerType.meta.type;
     const itemType = getTypeFromUnion(type, itemValue);

--- a/lib/components.js
+++ b/lib/components.js
@@ -734,14 +734,16 @@ export class List extends Component {
 
   // If there is an index go to the detail view of that item
   // otherwise create a new record
-  genNew(index){
+  // if a value is passed in, that will override an existing value
+  genNew(index, value=null){
     const { options, ctx } = this.props;
     const auto = this.getAuto();
     const i18n = this.getI18n();
     const config = this.getConfig();
     const stylesheet = this.getStylesheet();
     const templates = this.getTemplates();
-    const itemValue = Number.isInteger(index) ? this.state.value[index] : null;
+    const initialValue = value ? value : this.state.value[index]
+    const itemValue = Number.isInteger(index) ? initialValue : null;
     const i = Number.isInteger(index) ? index : this.state.value.length
     const type = this.typeInfo.innerType.meta.type;
     const itemType = getTypeFromUnion(type, itemValue);


### PR DESCRIPTION
We added genNew to tcomb under Classic Kyle's rule, which would take in an index, or return an empty value list entry if there was no index. We need to expand this functionality a bit to allow us to pass in a value. Related to RN-584 - grouped list component work. 