### PR TITLE
RN-642: Remove deprecated datepicker to support RN 0.60+ upgrade

### DIFF
--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -1,99 +1,105 @@
-var React = require('react');
-var { View, Text, DatePickerAndroid, TimePickerAndroid, TouchableNativeFeedback } = require('react-native');
+var React = require("react")
+var { View, Text, TouchableNativeFeedback } = require("react-native")
+var { DateTimePickerAndroid } = require("@react-native-community/datetimepicker")
 
 function datepicker(locals) {
-  if (locals.hidden) {
-    return null;
-  }
-
-  var stylesheet = locals.stylesheet;
-  var formGroupStyle = stylesheet.formGroup.normal;
-  var controlLabelStyle = stylesheet.controlLabel.normal;
-  var datepickerStyle = stylesheet.datepicker.normal;
-  var helpBlockStyle = stylesheet.helpBlock.normal;
-  var errorBlockStyle = stylesheet.errorBlock;
-  var dateValueStyle = stylesheet.dateValue.normal;
-
-  if (locals.hasError) {
-    formGroupStyle = stylesheet.formGroup.error;
-    controlLabelStyle = stylesheet.controlLabel.error;
-    datepickerStyle = stylesheet.datepicker.error;
-    helpBlockStyle = stylesheet.helpBlock.error;
-    dateValueStyle = stylesheet.dateValue.error;
-  }
-
-  // Setup the picker mode
-  var datePickerMode = 'date';
-  if (locals.mode === 'date' || locals.mode === 'time') {
-    datePickerMode = locals.mode;
-  }
-
-  /**
-   * Check config locals for Android datepicker.
-   * ``locals.config.background``: `TouchableNativeFeedback` background prop
-   * ``locals.config.format``: Date format function
-   */
-  var formattedValue = String(locals.value);
-  var background = TouchableNativeFeedback.SelectableBackground(); // eslint-disable-line new-cap
-  if (locals.config) {
-    if (locals.config.format) {
-      formattedValue = locals.config.format(locals.value);
+    if (locals.hidden) {
+        return null
     }
-    if (locals.config.background) {
-      background = locals.config.background;
+
+    var stylesheet = locals.stylesheet
+    var formGroupStyle = stylesheet.formGroup.normal
+    var controlLabelStyle = stylesheet.controlLabel.normal
+    var datepickerStyle = stylesheet.datepicker.normal
+    var helpBlockStyle = stylesheet.helpBlock.normal
+    var errorBlockStyle = stylesheet.errorBlock
+    var dateValueStyle = stylesheet.dateValue.normal
+
+    if (locals.hasError) {
+        formGroupStyle = stylesheet.formGroup.error
+        controlLabelStyle = stylesheet.controlLabel.error
+        datepickerStyle = stylesheet.datepicker.error
+        helpBlockStyle = stylesheet.helpBlock.error
+        dateValueStyle = stylesheet.dateValue.error
     }
-  }
 
-  var label = locals.label ? <Text style={controlLabelStyle}>{locals.label}</Text> : null;
-  var help = locals.help ? <Text style={helpBlockStyle}>{locals.help}</Text> : null;
-  var error = locals.hasError && locals.error ? <Text accessibilityLiveRegion="polite" style={errorBlockStyle}>{locals.error}</Text> : null;
-  var value = locals.value ? <Text style={dateValueStyle}>{formattedValue}</Text> : null;
+    // Setup the picker mode
+    var datePickerMode = "date"
+    if (locals.mode === "date" || locals.mode === "time") {
+        datePickerMode = locals.mode
+    }
 
-  return (
-    <View style={formGroupStyle}>
-      <TouchableNativeFeedback
-        accessible={true}
-        ref="input"
-        background={background}
-        onPress={function () {
-          if (datePickerMode === 'time') {
-            TimePickerAndroid.open({is24Hour: true})
-            .then(function (time) {
-              if (time.action !== TimePickerAndroid.dismissedAction) {
-                const newTime = new Date();
-                newTime.setHours(time.hour);
-                newTime.setMinutes(time.minute);
-                locals.onChange(newTime);
-              }
-            });
-          } else {
-            let config = {
-              date: locals.value || new Date()
-            };
-            if (locals.minimumDate) {
-              config.minDate = locals.minimumDate;
-            }
-            if (locals.maximumDate) {
-              config.maxDate = locals.maximumDate;
-            }
-            DatePickerAndroid.open(config)
-            .then(function (date) {
-              if (date.action !== DatePickerAndroid.dismissedAction) {
-                var newDate = new Date(date.year, date.month, date.day);
-                locals.onChange(newDate);
-              }
-            });
-          }
-        }}>
-        <View>
-          {label}
-          {value}
+    /**
+     * Check config locals for Android datepicker.
+     * ``locals.config.background``: `TouchableNativeFeedback` background prop
+     * ``locals.config.format``: Date format function
+     */
+    var formattedValue = String(locals.value)
+    var background = TouchableNativeFeedback.SelectableBackground() // eslint-disable-line new-cap
+    if (locals.config) {
+        if (locals.config.format) {
+            formattedValue = locals.config.format(locals.value)
+        }
+        if (locals.config.background) {
+            background = locals.config.background
+        }
+    }
+
+    var label = locals.label ? <Text style={controlLabelStyle}>{locals.label}</Text> : null
+    var help = locals.help ? <Text style={helpBlockStyle}>{locals.help}</Text> : null
+    var error =
+        locals.hasError && locals.error ? (
+            <Text accessibilityLiveRegion="polite" style={errorBlockStyle}>
+                {locals.error}
+            </Text>
+        ) : null
+    var value = locals.value ? <Text style={dateValueStyle}>{formattedValue}</Text> : null
+
+    return (
+        <View style={formGroupStyle}>
+            <TouchableNativeFeedback
+                accessible={true}
+                ref="input"
+                background={background}
+                onPress={function () {
+                    if (datePickerMode === "time") {
+                        DateTimePickerAndroid.open({ is24Hour: true, mode: "time" }).then(function (time) {
+                            if (time.action !== DateTimePickerAndroid.dismissedAction) {
+                                const newTime = new Date()
+                                newTime.setHours(time.hour)
+                                newTime.setMinutes(time.minute)
+                                locals.onChange(newTime)
+                            }
+                        })
+                    } else {
+                        let config = {
+                            value: locals.value || new Date(),
+                            mode: "date",
+                        }
+                        if (locals.minimumDate) {
+                            config.minDate = locals.minimumDate
+                        }
+                        if (locals.maximumDate) {
+                            config.maxDate = locals.maximumDate
+                        }
+                        DateTimePickerAndroid.open(config).then(function (date) {
+                            if (date.action !== DateTimePickerAndroid.dismissedAction) {
+                                var newDate = new Date(date.year, date.month, date.day)
+                                locals.onChange(newDate)
+                            }
+                        })
+                    }
+                }}
+            >
+                <View>
+                    {label}
+                    {value}
+                </View>
+            </TouchableNativeFeedback>
+            {help}
+            {error}
         </View>
-      </TouchableNativeFeedback>
-      {help}
-      {error}
-    </View>
-  );
+    )
 }
 
-module.exports = datepicker;
+module.exports = datepicker

--- a/package.json
+++ b/package.json
@@ -1,49 +1,50 @@
 {
-  "name": "tcomb-form-native",
-  "version": "0.6.4",
-  "description": "react-native powered UI library for developing forms writing less code",
-  "main": "index.js",
-  "scripts": {
-    "lint": "eslint lib",
-    "test": "npm run lint && babel-node test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/gcanti/tcomb-form-native.git"
-  },
-  "author": "Giulio Canti <giulio.canti@gmail.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/gcanti/tcomb-form-native/issues"
-  },
-  "homepage": "https://github.com/gcanti/tcomb-form-native",
-  "dependencies": {
-    "@rhumbix/tcomb-json-schema": "1.0.7",
-    "tcomb-validation": "^3.0.0"
-  },
-  "devDependencies": {
-    "babel": "5.8.34",
-    "babel-core": "5.8.34",
-    "babel-eslint": "^10.0.3",
-    "eslint": "^4.19.1",
-    "eslint-plugin-react": "2.5.2",
-    "react": "^15.0.0",
-    "tape": "3.5.0"
-  },
-  "tags": [
-    "tcomb",
-    "form",
-    "forms",
-    "react",
-    "react-native",
-    "react-component"
-  ],
-  "keywords": [
-    "tcomb",
-    "form",
-    "forms",
-    "react",
-    "react-native",
-    "react-component"
-  ]
+    "name": "tcomb-form-native",
+    "version": "0.6.4",
+    "description": "react-native powered UI library for developing forms writing less code",
+    "main": "index.js",
+    "scripts": {
+        "lint": "eslint lib",
+        "test": "npm run lint && babel-node test"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/gcanti/tcomb-form-native.git"
+    },
+    "author": "Giulio Canti <giulio.canti@gmail.com>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/gcanti/tcomb-form-native/issues"
+    },
+    "homepage": "https://github.com/gcanti/tcomb-form-native",
+    "dependencies": {
+        "@react-native-community/datetimepicker": "^2.4.0",
+        "@rhumbix/tcomb-json-schema": "1.0.7",
+        "tcomb-validation": "^3.0.0"
+    },
+    "devDependencies": {
+        "babel": "5.8.34",
+        "babel-core": "5.8.34",
+        "babel-eslint": "^10.0.3",
+        "eslint": "^4.19.1",
+        "eslint-plugin-react": "2.5.2",
+        "react": "^15.0.0",
+        "tape": "3.5.0"
+    },
+    "tags": [
+        "tcomb",
+        "form",
+        "forms",
+        "react",
+        "react-native",
+        "react-component"
+    ],
+    "keywords": [
+        "tcomb",
+        "form",
+        "forms",
+        "react",
+        "react-native",
+        "react-component"
+    ]
 }


### PR DESCRIPTION
This removes the TimePickerAndroid that has been deprecated and replaces it with the community DateTimePickerAndroid.